### PR TITLE
Fix : ProfilePageHeader style & UserNotFound 렌더 조건 수정

### DIFF
--- a/src/pages/Profile/ProfilePage.tsx
+++ b/src/pages/Profile/ProfilePage.tsx
@@ -41,7 +41,7 @@ const ProfilePage = () => {
     }
   }, [isLoading, isFetching]) // `isLoading`과 `isFetching` 상태 변경을 감지
 
-  if (!targetUserProfile) {
+  if (!targetUserProfile && !isFetching) {
     return <UserNotFound />
   }
 

--- a/src/pages/Profile/components/ProfilePageHeader.tsx
+++ b/src/pages/Profile/components/ProfilePageHeader.tsx
@@ -20,11 +20,11 @@ const ProfilePageHeader = ({
   playlists,
 }: ProfilePageHeaderProps) => {
   return (
-    <>
+    <div className="mb-[20px]">
       <UserCard
         size="medium"
         nickname={targetUserProfile.nickname}
-        className="mb-[20px]"
+        className="mb-[10px]"
         profileId={targetUserProfile.id}
         listCount={playlists.length}
       />
@@ -33,7 +33,7 @@ const ProfilePageHeader = ({
           <Button
             variant="outline"
             type="button"
-            className="bg-c600 text-c200 h-12 w-full"
+            className="bg-c600 text-c200 mt-[10px] h-12 w-full"
             onClick={() => setEditModalOpen(true)}
           >
             프로필 편집
@@ -46,7 +46,7 @@ const ProfilePageHeader = ({
           />
         </>
       )}
-    </>
+    </div>
   )
 }
 


### PR DESCRIPTION
## 📝 Task Details

- 프로필 페이지의 스타일을 수정했습니다.
- UserNotFound 렌더 조건을 수정했습니다.

## 📂 References

<img width="479" alt="스크린샷 2025-04-16 오전 1 13 10" src="https://github.com/user-attachments/assets/80f83866-0d0e-45f4-8bf7-a68f646e2042" />

